### PR TITLE
Expose advanced TTS conditioning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ curl -X POST "http://localhost:8000/v1/audio/speech" \
     "emotion": {
       "happiness": 1.0
     },
+    "pitch_std": 50.0,
+    "speaking_rate": 20.0,
+    "fmax": 22050,
+    "vqscore_8": [0.78, 0.78, 0.78, 0.78, 0.78, 0.78, 0.78, 0.78],
     "response_format": "mp3"
   }' \
   --output speech.mp3
@@ -172,6 +176,23 @@ response = requests.post(
 with open("output.mp3", "wb") as f:
     f.write(response.content)
 ```
+
+### Advanced Conditioning Parameters
+
+The `/v1/audio/speech` endpoint exposes additional optional fields that let you
+fine‑tune prosody and quality:
+
+- `pitch_std` (0–400) – controls pitch variation.
+- `speaking_rate` (0–40) – phonemes per second; overrides `speed`.
+- `fmax` (0–24000) – max frequency of the generated audio.
+- `vqscore_8` (8 floats 0.5–0.8) – target quality for each eighth of the
+  audio (hybrid model only).
+- `dnsmos_ovrl` (1–5) – MOS‑based quality metric (hybrid model only).
+- `speaker_noised` (bool) – whether to denoise the speaker embedding.
+
+These parameters default to sensible values. Override only the ones you need.
+For example, higher `pitch_std` and `speaking_rate` values will produce more
+expressive or faster speech, while `vqscore_8` can enforce cleaner audio.
 
 ## Features
 

--- a/main_zonos_tts_api.py
+++ b/main_zonos_tts_api.py
@@ -25,7 +25,7 @@ from typing import Dict, Optional, List, Union
 
 from fastapi import FastAPI, File, UploadFile, HTTPException, Form
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, conlist, confloat
 
 from zonos.model import Zonos
 from zonos.conditioning import make_cond_dict, supported_language_codes
@@ -128,6 +128,12 @@ class SpeechRequest(BaseModel):
     top_k: Optional[int] = Field(None, ge=1)
     top_p: Optional[float] = Field(None, ge=0.0, le=1.0)
     min_p: Optional[float] = Field(0.15, ge=0.0, le=1.0)
+    pitch_std: Optional[float] = Field(None, ge=0.0, le=400.0)
+    speaking_rate: Optional[float] = Field(None, ge=0.0, le=40.0)
+    fmax: Optional[float] = Field(None, ge=0.0, le=24000.0)
+    vqscore_8: Optional[conlist(confloat(ge=0.5, le=0.8), min_length=8, max_length=8)] = None
+    dnsmos_ovrl: Optional[float] = Field(None, ge=1.0, le=5.0)
+    speaker_noised: Optional[bool] = None
 
 class VoiceResponse(BaseModel):
     voice_id: str
@@ -164,15 +170,27 @@ async def create_speech(request: SpeechRequest):
         if request.voice and speaker_embedding is None:
             raise HTTPException(status_code=404, detail=f"Voice '{request.voice}' not found.")
 
-        cond_dict = make_cond_dict(
-            text=request.input,
-            language=request.language,
-            speaker=speaker_embedding,
-            emotion=emotion_tensor,
-            speaking_rate=speaking_rate,
-            device="cuda",
-            unconditional_keys=[] if request.emotion else ["emotion"],
-        )
+        cond_kwargs = {
+            "text": request.input,
+            "language": request.language,
+            "speaker": speaker_embedding,
+            "emotion": emotion_tensor,
+            "speaking_rate": request.speaking_rate if request.speaking_rate is not None else speaking_rate,
+            "device": "cuda",
+            "unconditional_keys": [] if request.emotion else ["emotion"],
+        }
+        if request.pitch_std is not None:
+            cond_kwargs["pitch_std"] = request.pitch_std
+        if request.fmax is not None:
+            cond_kwargs["fmax"] = request.fmax
+        if request.vqscore_8 is not None:
+            cond_kwargs["vqscore_8"] = request.vqscore_8
+        if request.dnsmos_ovrl is not None:
+            cond_kwargs["dnsmos_ovrl"] = request.dnsmos_ovrl
+        if request.speaker_noised is not None:
+            cond_kwargs["speaker_noised"] = request.speaker_noised
+
+        cond_dict = make_cond_dict(**cond_kwargs)
 
         conditioning = model.prepare_conditioning(cond_dict)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub heavy optional dependencies before importing the API module
+if "huggingface_hub" not in sys.modules:
+    hub = types.ModuleType("huggingface_hub")
+    hub.hf_hub_download = lambda *a, **k: ""
+    sys.modules["huggingface_hub"] = hub
+
+for mod in ["torchaudio", "safetensors", "inflect", "kanjize", "phonemizer.backend", "sudachipy"]:
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+if "torchaudio" in sys.modules:
+    sys.modules["torchaudio"].save = lambda *a, **k: None
+    sys.modules["torchaudio"].load = lambda *a, **k: (torch.zeros(1, 16000), 16000)
+
+if "kanjize" in sys.modules:
+    sys.modules["kanjize"].number2kanji = lambda x: x
+
+if "phonemizer.backend" in sys.modules:
+    sys.modules["phonemizer.backend"].EspeakBackend = object
+
+if "sudachipy" in sys.modules:
+    sud = sys.modules["sudachipy"]
+    class DummyDict:
+        def __init__(self, *a, **k): pass
+        def create(self):
+            class T: pass
+            return T()
+    sud.Dictionary = DummyDict
+    sud.SplitMode = object
+
+if "inflect" in sys.modules:
+    sys.modules["inflect"].engine = lambda: None
+
+if "transformers" not in sys.modules:
+    tr = types.ModuleType("transformers")
+    models = types.ModuleType("transformers.models")
+    dac = types.ModuleType("transformers.models.dac")
+    dac.DacModel = object
+    sys.modules["transformers.models"] = models
+    sys.modules["transformers.models.dac"] = dac
+    tr.models = models
+    sys.modules["transformers"] = tr
+
+import torch
+from fastapi.testclient import TestClient
+import main_zonos_tts_api as api
+
+class FakeAutoencoder:
+    sampling_rate = 22050
+    def decode(self, codes):
+        return torch.zeros(1, 160)
+
+class FakeModel:
+    def __init__(self):
+        self.autoencoder = FakeAutoencoder()
+        self.last_cond = None
+    def prepare_conditioning(self, cond_dict):
+        self.last_cond = cond_dict
+        return cond_dict
+    def generate(self, **kwargs):
+        return torch.zeros(1, 1, dtype=torch.long)
+
+def create_client(monkeypatch):
+    fake = FakeModel()
+    api.MODELS["transformer"] = fake
+    api.MODELS["hybrid"] = fake
+    monkeypatch.setattr(api, "load_models", lambda: None)
+    monkeypatch.setattr(api, "load_voice_embeddings", lambda: None)
+    monkeypatch.setattr(api, "make_cond_dict", lambda **kw: kw)
+    return TestClient(api.app), fake
+
+def test_advanced_params(monkeypatch):
+    client, model = create_client(monkeypatch)
+    payload = {
+        "input": "hi",
+        "pitch_std": 60.0,
+        "speaking_rate": 22.0,
+        "fmax": 24000,
+        "vqscore_8": [0.78]*8,
+        "dnsmos_ovrl": 4.0,
+        "speaker_noised": True
+    }
+    response = client.post("/v1/audio/speech", json=payload)
+    assert response.status_code == 200
+    assert model.last_cond["pitch_std"] == 60.0
+    assert model.last_cond["speaking_rate"] == 22.0
+    assert model.last_cond["fmax"] == 24000
+    assert model.last_cond["speaker_noised"] is True
+
+def test_defaults(monkeypatch):
+    client, model = create_client(monkeypatch)
+    response = client.post("/v1/audio/speech", json={"input": "hi"})
+    assert response.status_code == 200
+    assert model.last_cond["speaking_rate"] == 15.0


### PR DESCRIPTION
## Summary
- allow API clients to pass conditioning parameters like `pitch_std`, `speaking_rate`, and `fmax`
- document advanced conditioning usage
- add tests exercising the new API fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8f7aca288324a4c60687c1750a46