### PR TITLE
Return stack trace details on API errors

### DIFF
--- a/main_zonos_tts_api.py
+++ b/main_zonos_tts_api.py
@@ -226,7 +226,13 @@ async def create_speech(request: SpeechRequest):
 
     except Exception:
         logger.exception("Error during speech synthesis")
-        raise HTTPException(status_code=500, detail="Failed to generate speech")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "Failed to generate speech",
+                "traceback": traceback.format_exc(),
+            },
+        )
 
 @app.post("/v1/audio/voice")
 async def create_voice(file: UploadFile = File(...), name: Optional[str] = Form(None)):
@@ -249,7 +255,13 @@ async def create_voice(file: UploadFile = File(...), name: Optional[str] = Form(
 
     except Exception:
         logger.exception("Error during voice creation")
-        raise HTTPException(status_code=500, detail="Failed to process uploaded voice")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "Failed to process uploaded voice",
+                "traceback": traceback.format_exc(),
+            },
+        )
 
 @app.get("/v1/audio/voices")
 async def list_voices():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,77 @@ import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+# Provide a minimal torch stub if the real library is unavailable
+if "torch" not in sys.modules:
+    torch = types.ModuleType("torch")
+
+    class Tensor:
+        def __init__(self, shape=()):
+            self._shape = shape
+
+        def dim(self):
+            return len(self._shape)
+
+        def squeeze(self, *a, **k):
+            return self
+
+        def unsqueeze(self, *a, **k):
+            return self
+
+        def cpu(self):
+            return self
+
+        def detach(self):
+            return self
+
+    def zeros(*shape, **kwargs):
+        return Tensor(shape)
+
+    def tensor(data, device=None):
+        return Tensor((len(data),))
+
+    torch.zeros = zeros
+    torch.tensor = tensor
+    torch.Tensor = Tensor
+    torch.long = None
+    sys.modules["torch"] = torch
+
+# Stub logger to avoid filesystem access during tests
+if "logger" not in sys.modules:
+    logger_stub = types.ModuleType("logger")
+
+    def set_logger_name(*args, **kwargs):
+        pass
+
+    class DummyLogger:
+        def info(self, *a, **k):
+            pass
+
+        def error(self, *a, **k):
+            pass
+
+        def exception(self, *a, **k):
+            pass
+
+    logger_stub.set_logger_name = set_logger_name
+    logger_stub.logger = DummyLogger()
+    sys.modules["logger"] = logger_stub
+
+if "zonos" not in sys.modules:
+    zonos_pkg = types.ModuleType("zonos")
+    model_mod = types.ModuleType("zonos.model")
+    class DummyZonos:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return None
+    model_mod.Zonos = DummyZonos
+    conditioning_mod = types.ModuleType("zonos.conditioning")
+    conditioning_mod.make_cond_dict = lambda **kw: kw
+    conditioning_mod.supported_language_codes = []
+    sys.modules["zonos"] = zonos_pkg
+    sys.modules["zonos.model"] = model_mod
+    sys.modules["zonos.conditioning"] = conditioning_mod
+
 # Stub heavy optional dependencies before importing the API module
 if "huggingface_hub" not in sys.modules:
     hub = types.ModuleType("huggingface_hub")
@@ -98,3 +169,17 @@ def test_defaults(monkeypatch):
     response = client.post("/v1/audio/speech", json={"input": "hi"})
     assert response.status_code == 200
     assert model.last_cond["speaking_rate"] == 15.0
+
+
+def test_returns_traceback_on_error(monkeypatch):
+    client, model = create_client(monkeypatch)
+
+    def broken_generate(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(model, "generate", broken_generate)
+    response = client.post("/v1/audio/speech", json={"input": "hi"})
+    assert response.status_code == 500
+    detail = response.json()["detail"]
+    assert detail["error"] == "Failed to generate speech"
+    assert "RuntimeError: boom" in detail["traceback"]


### PR DESCRIPTION
## Summary
- include stack traces in 500 responses from speech synthesis and voice upload endpoints
- add regression test verifying that the API returns detailed error information

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c804c16d848324a0fafa2e8b6be3ac