### PR TITLE
Fix log directory default and improve hybrid model dependency error

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -10,12 +10,15 @@ BASE_DIR = (
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
 
-DEFAULT_LOG_DIR = Path(BASE_DIR, "log", "local")
-
-_env_log_dir = os.environ.get("LOG_DIR")
-if _env_log_dir:
-    LOG_DIR = str(Path(_env_log_dir))
-else:
-    LOG_DIR = str(DEFAULT_LOG_DIR)
+LOG_DIR = os.environ.get(
+    "LOG_DIR",
+    str(
+        Path(
+            BASE_DIR,
+            "log",
+            "local",
+        )
+    ),
+)
 
 LOGGING_DEBUG = os.environ.get("LOGGING_DEBUG", "True").lower() in ("true", "1", "yes")

--- a/config/config.py
+++ b/config/config.py
@@ -11,16 +11,11 @@ BASE_DIR = (
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
 
 DEFAULT_LOG_DIR = Path(BASE_DIR, "log", "local")
-LEGACY_LOG_DIR = Path(BASE_DIR, "logs", "local")
 
 _env_log_dir = os.environ.get("LOG_DIR")
 if _env_log_dir:
     LOG_DIR = str(Path(_env_log_dir))
 else:
-    # Prefer the corrected "log/" directory structure while preserving
-    # backwards compatibility with deployments that still have "logs/".
     LOG_DIR = str(DEFAULT_LOG_DIR)
-    if LEGACY_LOG_DIR.exists() and not DEFAULT_LOG_DIR.exists():
-        LOG_DIR = str(LEGACY_LOG_DIR)
 
 LOGGING_DEBUG = os.environ.get("LOGGING_DEBUG", "True").lower() in ("true", "1", "yes")

--- a/config/config.py
+++ b/config/config.py
@@ -15,7 +15,7 @@ LOG_DIR = os.environ.get(
     str(
         Path(
             BASE_DIR,
-            "log",
+            "logs",
             "local",
         )
     ),

--- a/config/config.py
+++ b/config/config.py
@@ -10,15 +10,17 @@ BASE_DIR = (
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
 
-LOG_DIR = os.environ.get(
-    "LOG_DIR",
-    str(
-        Path(
-            BASE_DIR,
-            "logs",
-            "local",
-        )
-    ),
-)
+DEFAULT_LOG_DIR = Path(BASE_DIR, "log", "local")
+LEGACY_LOG_DIR = Path(BASE_DIR, "logs", "local")
+
+_env_log_dir = os.environ.get("LOG_DIR")
+if _env_log_dir:
+    LOG_DIR = str(Path(_env_log_dir))
+else:
+    # Prefer the corrected "log/" directory structure while preserving
+    # backwards compatibility with deployments that still have "logs/".
+    LOG_DIR = str(DEFAULT_LOG_DIR)
+    if LEGACY_LOG_DIR.exists() and not DEFAULT_LOG_DIR.exists():
+        LOG_DIR = str(LEGACY_LOG_DIR)
 
 LOGGING_DEBUG = os.environ.get("LOGGING_DEBUG", "True").lower() in ("true", "1", "yes")

--- a/zonos/model.py
+++ b/zonos/model.py
@@ -68,6 +68,9 @@ class Zonos(nn.Module):
     ) -> "Zonos":
         config = ZonosConfig.from_dict(json.load(open(config_path)))
         requires_mamba = bool(config.backbone.ssm_cfg)
+        # Hybrid checkpoints populate `ssm_cfg`. The transformer backbone asserts this
+        # field is empty, so ensuring we select the mamba implementation (or fail with a
+        # clear error) avoids the runtime assertion users encountered previously.
 
         if backbone:
             backbone_cls = BACKBONES[backbone]

--- a/zonos/model.py
+++ b/zonos/model.py
@@ -66,15 +66,22 @@ class Zonos(nn.Module):
     def from_local(
         cls, config_path: str, model_path: str, device: str = DEFAULT_DEVICE, backbone: str | None = None
     ) -> "Zonos":
-        config = ZonosConfig.from_dict(json.load(open(config_path)))
+        with open(config_path) as config_file:
+            config = ZonosConfig.from_dict(json.load(config_file))
         if backbone:
             backbone_cls = BACKBONES[backbone]
         else:
-            is_transformer = not bool(config.backbone.ssm_cfg)
-            backbone_cls = DEFAULT_BACKBONE_CLS
-            # Preferentially route to pure torch backbone for increased performance and lower latency.
-            if is_transformer and "torch" in BACKBONES:
-                backbone_cls = BACKBONES["torch"]
+            uses_state_space = bool(config.backbone.ssm_cfg)
+            if uses_state_space:
+                if "mamba_ssm" not in BACKBONES:
+                    raise ImportError(
+                        "The requested model requires the optional mamba-ssm backend. "
+                        "Install it with `pip install mamba-ssm` or choose a transformer-only checkpoint."
+                    )
+                backbone_cls = BACKBONES["mamba_ssm"]
+            else:
+                # Preferentially route to pure torch backbone for increased performance and lower latency.
+                backbone_cls = BACKBONES.get("torch", DEFAULT_BACKBONE_CLS)
 
         model = cls(config, backbone_cls).to(device, torch.bfloat16)
         model.autoencoder.dac.to(device)

--- a/zonos/model.py
+++ b/zonos/model.py
@@ -67,14 +67,26 @@ class Zonos(nn.Module):
         cls, config_path: str, model_path: str, device: str = DEFAULT_DEVICE, backbone: str | None = None
     ) -> "Zonos":
         config = ZonosConfig.from_dict(json.load(open(config_path)))
+        requires_mamba = bool(config.backbone.ssm_cfg)
+
         if backbone:
             backbone_cls = BACKBONES[backbone]
+            if requires_mamba and backbone != "mamba_ssm":
+                raise RuntimeError(
+                    "This checkpoint requires the mamba-ssm backbone. "
+                    "Install the `mamba-ssm` package or omit the `backbone` override."
+                )
         else:
-            is_transformer = not bool(config.backbone.ssm_cfg)
-            backbone_cls = DEFAULT_BACKBONE_CLS
-            # Preferentially route to pure torch backbone for increased performance and lower latency.
-            if is_transformer and "torch" in BACKBONES:
-                backbone_cls = BACKBONES["torch"]
+            if requires_mamba:
+                if "mamba_ssm" not in BACKBONES:
+                    raise RuntimeError(
+                        "This checkpoint was trained with the mamba-ssm backbone, but the dependency "
+                        "is not installed. Install the `mamba-ssm` package to load it, or select a "
+                        "transformer-only checkpoint."
+                    )
+                backbone_cls = BACKBONES["mamba_ssm"]
+            else:
+                backbone_cls = BACKBONES.get("torch", DEFAULT_BACKBONE_CLS)
 
         model = cls(config, backbone_cls).to(device, torch.bfloat16)
         model.autoencoder.dac.to(device)

--- a/zonos/model.py
+++ b/zonos/model.py
@@ -66,22 +66,15 @@ class Zonos(nn.Module):
     def from_local(
         cls, config_path: str, model_path: str, device: str = DEFAULT_DEVICE, backbone: str | None = None
     ) -> "Zonos":
-        with open(config_path) as config_file:
-            config = ZonosConfig.from_dict(json.load(config_file))
+        config = ZonosConfig.from_dict(json.load(open(config_path)))
         if backbone:
             backbone_cls = BACKBONES[backbone]
         else:
-            uses_state_space = bool(config.backbone.ssm_cfg)
-            if uses_state_space:
-                if "mamba_ssm" not in BACKBONES:
-                    raise ImportError(
-                        "The requested model requires the optional mamba-ssm backend. "
-                        "Install it with `pip install mamba-ssm` or choose a transformer-only checkpoint."
-                    )
-                backbone_cls = BACKBONES["mamba_ssm"]
-            else:
-                # Preferentially route to pure torch backbone for increased performance and lower latency.
-                backbone_cls = BACKBONES.get("torch", DEFAULT_BACKBONE_CLS)
+            is_transformer = not bool(config.backbone.ssm_cfg)
+            backbone_cls = DEFAULT_BACKBONE_CLS
+            # Preferentially route to pure torch backbone for increased performance and lower latency.
+            if is_transformer and "torch" in BACKBONES:
+                backbone_cls = BACKBONES["torch"]
 
         model = cls(config, backbone_cls).to(device, torch.bfloat16)
         model.autoencoder.dac.to(device)


### PR DESCRIPTION
## Summary
- update the default LOG_DIR to point at the corrected `log/local` directory while gracefully handling legacy `logs/`
- ensure hybrid checkpoints select the mamba backend and raise a clear error when the dependency is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3c0cc6c883249f8a5689b9f75436