### PR TITLE
Handle apt cache lock during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
       /var/lib/dpkg/lock \
       /var/lib/apt/lists/lock; \
     \
+    # Heal any interrupted dpkg operations (ignore errors).
+    dpkg --configure -a || true; \
+    \
+    # Ensure required dir exists (can be missing in slim images).
+    mkdir -p /var/lib/apt/lists/partial; \
+    \
     # Update with retries for transient network issues.
     apt-get -o Acquire::Retries=3 update; \
     \
@@ -101,6 +107,12 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
       /var/lib/dpkg/lock-frontend \
       /var/lib/dpkg/lock \
       /var/lib/apt/lists/lock; \
+    \
+    # Heal any interrupted dpkg operations (ignore errors).
+    dpkg --configure -a || true; \
+    \
+    # Ensure required dir exists (can be missing in slim images).
+    mkdir -p /var/lib/apt/lists/partial; \
     \
     # Update with retries for transient network issues.
     apt-get -o Acquire::Retries=3 update; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,28 @@ WORKDIR /tmp/mamba
 
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos \
-    rm -f /var/cache/apt/archives/lock /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock && \
-    apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
+    set -eux; \
+    \
+    # Remove any stale APT/DPKG locks (cache mount can retain these).
+    rm -f \
+      /var/cache/apt/archives/lock \
+      /var/lib/dpkg/lock-frontend \
+      /var/lib/dpkg/lock \
+      /var/lib/apt/lists/lock; \
+    \
+    # Update with retries for transient network issues.
+    apt-get -o Acquire::Retries=3 update; \
+    \
+    # Install minimal deps without recommendations.
     apt-get install -y --no-install-recommends \
-        build-essential \
-        ninja-build \
-        git \
-    && rm -rf /var/lib/apt/lists/*
+      build-essential \
+      ninja-build \
+      git; \
+    \
+    # Clean package lists and cache to minimize layers.
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip setuptools wheel
 
@@ -78,16 +92,30 @@ WORKDIR /app
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 COPY requirements ./requirements
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos \
-    rm -f /var/cache/apt/archives/lock /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock && \
-    apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
+    set -eux; \
+    \
+    # Remove any stale APT/DPKG locks (cache mount can retain these).
+    rm -f \
+      /var/cache/apt/archives/lock \
+      /var/lib/dpkg/lock-frontend \
+      /var/lib/dpkg/lock \
+      /var/lib/apt/lists/lock; \
+    \
+    # Update with retries for transient network issues.
+    apt-get -o Acquire::Retries=3 update; \
+    \
+    # Install runtime deps without recommendations.
     apt-get install -y --no-install-recommends \
-        espeak-ng \
-        ffmpeg \
-        libsndfile1 \
-        curl \
-        git \
-    && rm -rf /var/lib/apt/lists/*
+      espeak-ng \
+      ffmpeg \
+      libsndfile1 \
+      curl \
+      git; \
+    \
+    # Clean package lists and cache to minimize layers.
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip setuptools wheel
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,8 +155,10 @@ RUN pip install --no-cache-dir --no-index --find-links=/tmp/wheels \
     flash-attn==2.7.3 \
     causal-conv1d==1.5.0.post8
 
-RUN if [ "$WITH_TORCHVISION" = "1" ]; then \
-      pip install --no-cache-dir --no-index --find-links=/tmp/wheels torchvision==0.21.0+cu124 ; \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-base \
+    if [ "$WITH_TORCHVISION" = "1" ]; then \
+      pip install --no-index --find-links=/tmp/wheels \
+        torchvision==0.21.0+cu124; \
     fi
 RUN rm -rf /tmp/wheels || true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ WORKDIR /tmp/mamba
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos \
-    apt update && \
-    apt install -y --no-install-recommends \
+    rm -f /var/cache/apt/archives/lock /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         build-essential \
         ninja-build \
         git \
@@ -78,8 +79,9 @@ COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 COPY requirements ./requirements
 
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos \
-    apt update && \
-    apt install -y --no-install-recommends \
+    rm -f /var/cache/apt/archives/lock /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         espeak-ng \
         ffmpeg \
         libsndfile1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     # Ensure required dir exists (can be missing in slim images).
     mkdir -p /var/lib/apt/lists/partial; \
     \
-    # Update with retries for transient network issues.
-    apt-get -o Acquire::Retries=3 update; \
+    # Update with retries (quiet mode) for transient network issues.
+    apt-get -o Acquire::Retries=3 -y -q update; \
     \
-    # Install minimal deps without recommendations.
-    apt-get install -y --no-install-recommends \
+    # Install minimal deps quietly without recommendations.
+    apt-get install -y -q --no-install-recommends \
       build-essential \
       ninja-build \
       git; \
@@ -49,7 +49,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder \
+    pip install --upgrade pip setuptools wheel
 
 RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
     pip install --no-cache-dir \
@@ -114,11 +115,11 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     # Ensure required dir exists (can be missing in slim images).
     mkdir -p /var/lib/apt/lists/partial; \
     \
-    # Update with retries for transient network issues.
-    apt-get -o Acquire::Retries=3 update; \
+    # Update with retries (quiet mode) for transient network issues.
+    apt-get -o Acquire::Retries=3 -y -q update; \
     \
-    # Install runtime deps without recommendations.
-    apt-get install -y --no-install-recommends \
+    # Install runtime deps quietly without recommendations.
+    apt-get install -y -q --no-install-recommends \
       espeak-ng \
       ffmpeg \
       libsndfile1 \
@@ -129,7 +130,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-base \
+    pip install --upgrade pip setuptools wheel
 
 RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
     pip install --no-cache-dir \


### PR DESCRIPTION
## Summary
- clear cached apt lock files before running package installs in the Dockerfile
- switch to apt-get to avoid non-script usage warnings during cached installations

## Testing
- docker build --progress=plain --target mamba-builder --build-arg WITH_TORCHVISION=0 . *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1fc6f1cc8324bb76d91ce9fe5fe8