### PR TITLE
Fix Docker mamba wheel build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
 
 RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
     PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-    pip wheel --no-cache-dir --no-binary=:all: \
+    pip wheel --no-cache-dir --no-binary=mamba-ssm \
     -c constraints/torch-cu124-mamba.txt \
     mamba-ssm==2.2.5 \
     -w /tmp/wheels


### PR DESCRIPTION
## Summary
- allow pip to use binary torch while building the `mamba-ssm` wheel so build dependencies can resolve

## Testing
- not run (docker change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc994c633c8324bf5c4b84de270597