### PR TITLE
Switch Dockerfile to uv and runtime base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,20 @@
-# VCS and metadata
+# VCS
 .git
 .gitignore
 .gitattributes
 
 # Python cache and build artifacts
 **/__pycache__/
+__pycache__/
+*.py[cod]
 **/*.py[co]
+*.pyd
+*.so
 *.egg-info/
 .build/
 build/
 dist/
+.cache/
 
 # Environments
 .env
@@ -17,15 +22,17 @@ dist/
 .venv/
 venv/
 
+# Node / frontend dependencies
+node_modules/
+
 # OS / editor junk
 **/.DS_Store
+.DS_Store
+Thumbs.db
 *.swp
 *.swo
 .idea/
 .vscode/
-
-# Node / frontend dependencies
-node_modules/
 
 # Test artifacts
 .coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN python - <<'PY'
+RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=uv-toolchain-probe \
+    python - <<'PY'
 import shutil, sys
 
 checks = {
@@ -126,6 +127,24 @@ WORKDIR /app
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 COPY requirements ./requirements
 
+RUN --mount=type=cache,target=/root/.cache/req-scan,id=uv-req-sanity \
+    python - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path('requirements/runtime.txt').read_text()
+pattern = re.compile(r"(git\+|git@|vcs)")
+
+suspicious = [line.strip() for line in text.splitlines() if pattern.search(line.lower())]
+
+if suspicious:
+    print('VCS-like deps in requirements/runtime.txt:', suspicious)
+    sys.exit(1)
+
+print('Requirements sanity: OK')
+PY
+
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     set -eux; \
     \
@@ -194,7 +213,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
-RUN python - <<'PY'
+RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=uv-vcs-sanity \
+    python - <<'PY'
 from pathlib import Path
 import re
 import sys

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,56 +44,63 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     apt-get install -y -q --no-install-recommends \
       build-essential \
       ninja-build \
-      git; \
+      git \
+      curl; \
     \
     # Clean package lists and cache to minimize layers.
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder \
-    pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
-    PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-    pip install --no-cache-dir \
-    -c constraints/torch-cu124-mamba.txt \
-    torch==2.6.0+cu124 \
-    torchaudio==2.6.0+cu124
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+    uv pip install --system --no-cache-dir \
+      -c constraints/torch-cu124-mamba.txt \
+      --index-url ${TORCH_CUDA_INDEX_URL} \
+      --extra-index-url ${PYPI_INDEX_URL} \
+      torch==2.6.0+cu124 \
+      torchaudio==2.6.0+cu124
 
 # Deterministic local build of mamba-ssm. We disable build isolation so the
 # build uses the Torch we pinned earlier in this stage, and we force source
 # build to avoid any network wheel guessing.
-RUN \
-    PIP_NO_BUILD_ISOLATION=1 \
-    MAMBA_FORCE_BUILD=TRUE \
-    PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
-    PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-    pip wheel --no-cache-dir --no-binary=mamba-ssm \
-    -c constraints/torch-cu124-mamba.txt \
-    mamba-ssm==2.2.5 \
-    -w /tmp/wheels
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+    PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
+    uv pip wheel \
+      -c constraints/torch-cu124-mamba.txt \
+      --index-url ${TORCH_CUDA_INDEX_URL} \
+      --extra-index-url ${PYPI_INDEX_URL} \
+      --no-binary=mamba-ssm \
+      --wheel-dir /tmp/wheels \
+      mamba-ssm==2.2.5
 
-RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
-    PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-    pip wheel --no-cache-dir --no-binary=:all: \
-    -c constraints/torch-cu124-mamba.txt \
-    flash-attn==2.7.3 \
-    causal-conv1d==1.5.0.post8 \
-    -w /tmp/wheels
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+    uv pip wheel \
+      -c constraints/torch-cu124-mamba.txt \
+      --index-url ${TORCH_CUDA_INDEX_URL} \
+      --extra-index-url ${PYPI_INDEX_URL} \
+      --no-binary=:all: \
+      --wheel-dir /tmp/wheels \
+      flash-attn==2.7.3 \
+      causal-conv1d==1.5.0.post8
 
-RUN if [ "$WITH_TORCHVISION" = "1" ]; then \
-      PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
-      PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-      pip wheel --no-cache-dir --no-binary=:all: \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+    if [ "$WITH_TORCHVISION" = "1" ]; then \
+      uv pip wheel \
         -c constraints/torch-cu124-mamba.txt \
-        torchvision==0.21.0+cu124 \
-        -w /tmp/wheels ; \
+        --index-url ${TORCH_CUDA_INDEX_URL} \
+        --extra-index-url ${PYPI_INDEX_URL} \
+        --no-binary=:all: \
+        --wheel-dir /tmp/wheels \
+        torchvision==0.21.0+cu124 ; \
     fi
 
 # ========================================================
-# Stage 1 — Base layer with Python and system deps
+# Stage 1 — Base layer with Python and system deps (slimmer runtime)
 # ========================================================
-FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel@sha256:0cf3402e946b7c384ba943ee05c90b4c5a4a05227923921f2b0918c011cfaf56 AS base
+FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime AS base
 ARG WITH_TORCHVISION
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -135,22 +142,23 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
       espeak-ng \
       ffmpeg \
       libsndfile1 \
-      curl \
-      git; \
+      curl; \
     \
     # Clean package lists and cache to minimize layers.
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-base \
-    pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN PIP_INDEX_URL=${TORCH_CUDA_INDEX_URL} \
-    PIP_EXTRA_INDEX_URL=${PYPI_INDEX_URL} \
-    pip install --no-cache-dir \
-    -c constraints/torch-cu124-mamba.txt \
-    torch==2.6.0+cu124 \
-    torchaudio==2.6.0+cu124
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+    uv pip install --system --no-cache-dir \
+      -c constraints/torch-cu124-mamba.txt \
+      --index-url ${TORCH_CUDA_INDEX_URL} \
+      --extra-index-url ${PYPI_INDEX_URL} \
+      torch==2.6.0+cu124 \
+      torchaudio==2.6.0+cu124
 
 RUN python - <<'PY'
 import sys
@@ -160,24 +168,27 @@ print('Torch file:', getattr(torch, '__file__', '<missing>'))
 print('Python prefix:', sys.prefix)
 PY
 
-RUN pip install --no-cache-dir -r requirements/runtime.txt
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+    uv pip install --system --no-cache-dir -r requirements/runtime.txt
 
 COPY --from=mamba-builder /tmp/wheels /tmp/wheels
-RUN pip install --no-cache-dir --no-index --find-links=/tmp/wheels \
-    mamba-ssm==2.2.5 \
-    flash-attn==2.7.3 \
-    causal-conv1d==1.5.0.post8
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+    uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
+      mamba-ssm==2.2.5 \
+      flash-attn==2.7.3 \
+      causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
-      pip install --no-index --find-links=/tmp/wheels \
+      uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
         torchvision==0.21.0+cu124; \
     fi
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
 COPY zonos ./zonos
-RUN pip install --no-cache-dir --no-deps -e .
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+    uv pip install --system --no-cache-dir --no-deps -e .
 
 RUN python - <<'PY'
 import sys

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,12 +62,12 @@ if not all(checks.values()):
     sys.exit(1)
 PY
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-install \
     set -eux; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -78,7 +78,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
 # Deterministic local build of mamba-ssm. We disable build isolation so the
 # build uses the Torch we pinned earlier in this stage, and we force source
 # build to avoid any network wheel guessing.
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-02-mamba \
     PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
     uv pip wheel \
       -c constraints/torch-cu124-mamba.txt \
@@ -88,7 +88,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
       --wheel-dir /tmp/wheels \
       mamba-ssm==2.2.5
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-03-flashcausal \
     uv pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -98,7 +98,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-04-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       uv pip wheel \
         -c constraints/torch-cu124-mamba.txt \
@@ -174,12 +174,12 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
     set -eux; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-01-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -195,17 +195,17 @@ print('Torch file:', getattr(torch, '__file__', '<missing>'))
 print('Python prefix:', sys.prefix)
 PY
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-02-reqs \
     uv pip install --system --no-cache-dir -r requirements/runtime.txt
 
 COPY --from=mamba-builder /tmp/wheels /tmp/wheels
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-03-localwheels \
     uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
       mamba-ssm==2.2.5 \
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-04-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
         torchvision==0.21.0+cu124; \
@@ -264,7 +264,7 @@ if suspicious:
 print('Editable install sanity: OK')
 PY
 COPY zonos ./zonos
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05-editable \
     uv pip install --system --no-cache-dir --no-deps -e .
 
 RUN python - <<'PY'

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,32 +49,21 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     rm -rf /var/lib/apt/lists/*
 
 RUN python - <<'PY'
-import shutil
-import subprocess
-import sys
+import shutil, sys
 
 checks = {
     'nvcc': shutil.which('nvcc') is not None,
     'ninja': shutil.which('ninja') is not None,
 }
 
-if checks['nvcc']:
-    result = subprocess.run(['nvcc', '--version'], capture_output=True)
-    checks['cuda_home'] = result.returncode == 0
-else:
-    checks['cuda_home'] = False
-
 print('Toolchain:', checks)
-
 if not all(checks.values()):
     sys.exit(1)
 PY
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
     set -eux; \
-    curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-installer.sh; \
-    sh /tmp/uv-installer.sh; \
-    rm -f /tmp/uv-installer.sh; \
+    curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
@@ -160,8 +149,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     apt-get install -y -q --no-install-recommends \
       espeak-ng \
       ffmpeg \
-      libsndfile1 \
-      curl; \
+      libsndfile1; \
     \
     # Clean package lists and cache to minimize layers.
     apt-get clean; \
@@ -169,9 +157,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     set -eux; \
-    curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-installer.sh; \
-    sh /tmp/uv-installer.sh; \
-    rm -f /tmp/uv-installer.sh; \
+    curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ if not all(checks.values()):
 PY
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-install \
+    # Pin uv installer to a known-good release for reproducibility.
+    export UV_INSTALLER_VERSION="0.4.0"; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \
@@ -202,6 +204,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uv-insta
       curl \
       ca-certificates; \
     \
+    # Pin uv installer to a known-good release for reproducibility.
+    export UV_INSTALLER_VERSION="0.4.0"; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,13 @@ PY
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-install \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
-    ln -sf /root/.local/bin/uv /usr/local/bin/uv
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
+    \
+    # Remove curl now that uv is available in the builder.
+    apt-get purge -y curl; \
+    apt-get autoremove -y; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch \
     uv pip install --system --no-cache-dir \
@@ -172,7 +178,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uvinstall \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uv-install \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
@@ -199,8 +205,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uvinstal
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \
-    # Remove curl and tidy up so the runtime layer stays slim.
-    apt-get purge -y curl ca-certificates; \
+    # Remove curl (keep ca-certificates for TLS).
+    apt-get purge -y curl; \
     apt-get autoremove -y; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /tmp/mamba
 
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-00-apt \
     set -eux; \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
@@ -145,7 +145,7 @@ if suspicious:
 print('Requirements sanity: OK')
 PY
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
     set -eux; \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
@@ -174,10 +174,39 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uvinstall \
+    --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
     set -eux; \
+    \
+    # Remove any stale APT/DPKG locks (cache mount can retain these).
+    rm -f \
+      /var/cache/apt/archives/lock \
+      /var/lib/dpkg/lock-frontend \
+      /var/lib/dpkg/lock \
+      /var/lib/apt/lists/lock; \
+    \
+    # Heal any interrupted dpkg operations (ignore errors).
+    dpkg --configure -a || true; \
+    \
+    # Ensure required dir exists (can be missing in slim images).
+    mkdir -p /var/lib/apt/lists/partial; \
+    \
+    # Update with retries (quiet mode) for transient network issues.
+    apt-get -o Acquire::Retries=3 -y -q update; \
+    \
+    # Install curl and certificates temporarily for the uv installer.
+    apt-get install -y -q --no-install-recommends \
+      curl \
+      ca-certificates; \
+    \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
-    ln -sf /root/.local/bin/uv /usr/local/bin/uv
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
+    \
+    # Remove curl and tidy up so the runtime layer stays slim.
+    apt-get purge -y curl; \
+    apt-get autoremove -y; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-01-torch \
     uv pip install --system --no-cache-dir \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 # Stage 0 — Build CUDA wheels against pinned torch
 # Update the digest with tools/docker/update_pytorch_digest.sh when refreshing the base image
 # ========================================================
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 ARG WITH_TORCHVISION=0
 FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel@sha256:0cf3402e946b7c384ba943ee05c90b4c5a4a05227923921f2b0918c011cfaf56 AS mamba-builder
 ARG WITH_TORCHVISION
@@ -19,7 +20,6 @@ WORKDIR /tmp/mamba
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-00-apt \
-    set -eux; \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -63,7 +63,6 @@ if not all(checks.values()):
 PY
 
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-install \
-    set -eux; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
@@ -146,7 +145,6 @@ print('Requirements sanity: OK')
 PY
 
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
-    set -eux; \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -176,7 +174,6 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
 
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uvinstall \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
-    set -eux; \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -203,7 +200,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uvinstal
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \
     # Remove curl and tidy up so the runtime layer stays slim.
-    apt-get purge -y curl; \
+    apt-get purge -y curl ca-certificates; \
     apt-get autoremove -y; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,7 @@ ARG WITH_TORCHVISION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TORCH_CUDA_INDEX_URL=https://download.pytorch.org/whl/cu124 \
-    PYPI_INDEX_URL=https://pypi.org/simple \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_COLOR=1 \
-    PIP_DEFAULT_TIMEOUT=60
+    PYPI_INDEX_URL=https://pypi.org/simple
 
 WORKDIR /tmp/mamba
 
@@ -51,11 +48,36 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN python - <<'PY'
+import shutil
+import subprocess
+import sys
+
+checks = {
+    'nvcc': shutil.which('nvcc') is not None,
+    'ninja': shutil.which('ninja') is not None,
+}
+
+if checks['nvcc']:
+    result = subprocess.run(['nvcc', '--version'], capture_output=True)
+    checks['cuda_home'] = result.returncode == 0
+else:
+    checks['cuda_home'] = False
+
+print('Toolchain:', checks)
+
+if not all(checks.values()):
+    sys.exit(1)
+PY
+
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
+    set -eux; \
+    curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-installer.sh; \
+    sh /tmp/uv-installer.sh; \
+    rm -f /tmp/uv-installer.sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -66,7 +88,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
 # Deterministic local build of mamba-ssm. We disable build isolation so the
 # build uses the Torch we pinned earlier in this stage, and we force source
 # build to avoid any network wheel guessing.
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
     PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
     uv pip wheel \
       -c constraints/torch-cu124-mamba.txt \
@@ -76,7 +98,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
       --wheel-dir /tmp/wheels \
       mamba-ssm==2.2.5
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
     uv pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -86,7 +108,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       uv pip wheel \
         -c constraints/torch-cu124-mamba.txt \
@@ -100,15 +122,12 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-builder \
 # ========================================================
 # Stage 1 — Base layer with Python and system deps (slimmer runtime)
 # ========================================================
-FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime AS base
+FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime@sha256:77f17f843507062875ce8be2a6f76aa6aa3df7f9ef1e31d9d7432f4b0f563dee AS base
 ARG WITH_TORCHVISION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TORCH_CUDA_INDEX_URL=https://download.pytorch.org/whl/cu124 \
-    PYPI_INDEX_URL=https://pypi.org/simple \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_COLOR=1 \
-    PIP_DEFAULT_TIMEOUT=60
+    PYPI_INDEX_URL=https://pypi.org/simple
 
 LABEL built-by="Ctrl+C Ctrl+V DevOps - Thanks Chat" \
       purpose="API container that yells in beautiful voices"
@@ -148,11 +167,14 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
+    set -eux; \
+    curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-installer.sh; \
+    sh /tmp/uv-installer.sh; \
+    rm -f /tmp/uv-installer.sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -168,17 +190,17 @@ print('Torch file:', getattr(torch, '__file__', '<missing>'))
 print('Python prefix:', sys.prefix)
 PY
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     uv pip install --system --no-cache-dir -r requirements/runtime.txt
 
 COPY --from=mamba-builder /tmp/wheels /tmp/wheels
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
       mamba-ssm==2.2.5 \
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
         torchvision==0.21.0+cu124; \
@@ -186,8 +208,57 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
+RUN python - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path('pyproject.toml').read_text()
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    tomllib = None
+
+suspicious = []
+pattern = re.compile(r'(^|[^a-z0-9])vcs([^a-z0-9]|$)')
+
+if tomllib is not None:
+    data = tomllib.loads(text)
+    project = data.get('project', {})
+
+    def _collect(value):
+        collected = []
+        if isinstance(value, dict):
+            for item in value.values():
+                collected.extend(item)
+        elif isinstance(value, (list, tuple, set)):
+            collected.extend(value)
+        elif value:
+            collected.append(value)
+        return collected
+
+    deps = _collect(project.get('dependencies', []))
+    deps += _collect(project.get('optional-dependencies', {}))
+
+    for dep in deps:
+        lower = str(dep).lower()
+        if 'git+' in lower or 'git@' in lower or pattern.search(lower):
+            suspicious.append(dep)
+else:
+    for line in text.splitlines():
+        lower = line.lower()
+        if 'git+' in lower or 'git@' in lower or pattern.search(lower):
+            suspicious.append(line.strip())
+
+if suspicious:
+    print('VCS-like deps found:', suspicious)
+    sys.exit(1)
+
+print('Editable install sanity: OK')
+PY
 COPY zonos ./zonos
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-base \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base \
     uv pip install --system --no-cache-dir --no-deps -e .
 
 RUN python - <<'PY'


### PR DESCRIPTION
## Summary
- install uv in both the builder and runtime stages and replace pip commands with uv pip to honour constraints and index flags
- reuse uv cache mounts for CUDA wheel builds, keeping the deterministic mamba-ssm source build and optional torchvision wheel
- move the base stage onto the cudnn9 runtime image and remove unused git from runtime packages to slim the final image

## Testing
- not run (docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd571119f88324bba2af02c2264cfa