### PR TITLE
Fix wheel build steps in mamba builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-08-vision \
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
-RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=vcs-sanity-uv-09-scan \
+RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=vcs-sanity-zonos-base-09-scan \
     python - <<'PY'
 from pathlib import Path
 import re

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-01-apt \
     rm -rf /var/lib/apt/lists/*
 
 # --- Toolchain smoke test (nvcc/ninja present) --------------------------------
-RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=toolchain-probe-zonos-builder-02 \
+RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=toolchain-cache-zonos-builder-02-probe \
     python - <<'PY'
 import shutil, sys
 
@@ -67,8 +67,8 @@ PY
 
 # --- uv install (fast prebuilt installs). Wheels will be built with pip -------
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-03-install \
-    export UV_INSTALLER_VERSION="0.4.0"; \
-    curl -LsSf https://astral.sh/uv/install.sh | sh; \
+    # Note: first -- ends sh options; second --version is passed to the installer
+    curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --version 0.4.0; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \
     # Remove curl now that uv is available in the builder.
@@ -143,7 +143,7 @@ WORKDIR /app
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 COPY requirements ./requirements
 
-RUN --mount=type=cache,target=/root/.cache/req-scan,id=uv-req-sanity \
+RUN --mount=type=cache,target=/root/.cache/req-scan,id=req-sanity-zonos-base-01-scan \
     python - <<'PY'
 from pathlib import Path
 import re
@@ -161,7 +161,7 @@ if suspicious:
 print('Requirements sanity: OK')
 PY
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-02-apt \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -189,8 +189,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-00-apt \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uv-install \
-    --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-00-uv-install \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-03-uv-install \
+    --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-04-uv-install \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -214,8 +214,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uv-insta
       ca-certificates; \
     \
     # Pin uv installer to a known-good release for reproducibility.
-    export UV_INSTALLER_VERSION="0.4.0"; \
-    curl -LsSf https://astral.sh/uv/install.sh | sh; \
+    # Note: first -- ends sh options; second --version is passed to the installer
+    curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --version 0.4.0; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
     \
     # Remove curl (keep ca-certificates for TLS).
@@ -224,7 +224,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-01-uv-insta
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-01-torch \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -240,17 +240,17 @@ print('Torch file:', getattr(torch, '__file__', '<missing>'))
 print('Python prefix:', sys.prefix)
 PY
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-02-reqs \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-06-reqs \
     uv pip install --system --no-cache-dir -r requirements/runtime.txt
 
 COPY --from=mamba-builder /tmp/wheels /tmp/wheels
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-03-localwheels \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-07-localwheels \
     uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
       mamba-ssm==2.2.5 \
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-04-vision \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-08-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       uv pip install --system --no-cache-dir --no-index --find-links=/tmp/wheels \
         torchvision==0.21.0+cu124; \
@@ -258,7 +258,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-04-vision \
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
-RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=uv-vcs-sanity \
+RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=vcs-sanity-uv-09-scan \
     python - <<'PY'
 from pathlib import Path
 import re
@@ -309,7 +309,7 @@ if suspicious:
 print('Editable install sanity: OK')
 PY
 COPY zonos ./zonos
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05-editable \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-10-editable \
     uv pip install --system --no-cache-dir --no-deps -e .
 
 RUN python - <<'PY'

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /tmp/mamba
 
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
 # --- APT bootstrap (build essentials, ninja, curl for uv installer) -----------
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-10-apt \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-01-apt \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-10-apt \
     rm -rf /var/lib/apt/lists/*
 
 # --- Toolchain smoke test (nvcc/ninja present) --------------------------------
-RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=toolchain-probe-zonos-builder-10 \
+RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=toolchain-probe-zonos-builder-02 \
     python - <<'PY'
 import shutil, sys
 
@@ -65,7 +65,7 @@ if not all(checks.values()):
 PY
 
 # --- uv install (fast prebuilt installs). Wheels will be built with pip -------
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-20-install \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-03-install \
     export UV_INSTALLER_VERSION="0.4.0"; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
@@ -77,11 +77,11 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-20-insta
     rm -rf /var/lib/apt/lists/*
 
 # --- pip bootstrap (for building wheels) --------------------------------------
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-20-bootstrap \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-04-bootstrap \
     python -m pip install --upgrade pip setuptools wheel
 
 # --- Install pinned torch/torchaudio (prebuilt wheels via uv) -----------------
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-30-torch \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-05-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -91,7 +91,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-30-torch
 
 # --- Build wheels (source builds with pip wheel) -------------------------------
 # mamba-ssm from source; reuse pinned Torch in this stage.
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-40-mamba \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-06-mamba \
     PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
     python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
@@ -101,7 +101,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-40-mam
       --wheel-dir /tmp/wheels \
       mamba-ssm==2.2.5
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-50-flashcausal \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-07-flashcausal \
     python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -111,7 +111,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-50-fla
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-60-vision \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-08-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       python -m pip wheel \
         -c constraints/torch-cu124-mamba.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-in
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-00-bootstrap \
+    python -m pip install --upgrade pip setuptools wheel
+
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
@@ -86,9 +89,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch
 # Deterministic local build of mamba-ssm. We disable build isolation so the
 # build uses the Torch we pinned earlier in this stage, and we force source
 # build to avoid any network wheel guessing.
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-02-mamba \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-02-mamba \
     PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
-    uv pip wheel \
+    python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
       --extra-index-url ${PYPI_INDEX_URL} \
@@ -96,8 +99,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-02-mamba
       --wheel-dir /tmp/wheels \
       mamba-ssm==2.2.5
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-03-flashcausal \
-    uv pip wheel \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-03-flashcausal \
+    python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
       --extra-index-url ${PYPI_INDEX_URL} \
@@ -106,9 +109,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-03-flash
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-04-vision \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-04-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
-      uv pip wheel \
+      python -m pip wheel \
         -c constraints/torch-cu124-mamba.txt \
         --index-url ${TORCH_CUDA_INDEX_URL} \
         --extra-index-url ${PYPI_INDEX_URL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 WORKDIR /tmp/mamba
 
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
+
 # --- APT bootstrap (build essentials, ninja, curl for uv installer) -----------
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-01-apt \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 
 # ========================================================
 # Stage 0 — Build CUDA wheels against pinned torch
-# MUST use the *devel* variant: this stage compiles CUDA/C++ extensions (nvcc, headers).
-# Update the digest with tools/docker/update_pytorch_digest.sh when refreshing the base image
+# MUST use the *devel* variant: compiles CUDA/C++ extensions (nvcc, headers).
+# Update digest with tools/docker/update_pytorch_digest.sh when refreshing base image
 # ========================================================
 ARG WITH_TORCHVISION=0
 FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel@sha256:0cf3402e946b7c384ba943ee05c90b4c5a4a05227923921f2b0918c011cfaf56 AS mamba-builder
@@ -19,8 +19,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 WORKDIR /tmp/mamba
 
 COPY constraints/torch-cu124-mamba.txt ./constraints/torch-cu124-mamba.txt
-
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-00-apt \
+# --- APT bootstrap (build essentials, ninja, curl for uv installer) -----------
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-10-apt \
     \
     # Remove any stale APT/DPKG locks (cache mount can retain these).
     rm -f \
@@ -49,7 +49,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-builder-00-apt \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=uv-toolchain-probe \
+# --- Toolchain smoke test (nvcc/ninja present) --------------------------------
+RUN --mount=type=cache,target=/root/.cache/toolchain-probe,id=toolchain-probe-zonos-builder-10 \
     python - <<'PY'
 import shutil, sys
 
@@ -63,8 +64,8 @@ if not all(checks.values()):
     sys.exit(1)
 PY
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-install \
-    # Pin uv installer to a known-good release for reproducibility.
+# --- uv install (fast prebuilt installs). Wheels will be built with pip -------
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-20-install \
     export UV_INSTALLER_VERSION="0.4.0"; \
     curl -LsSf https://astral.sh/uv/install.sh | sh; \
     ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
@@ -75,10 +76,12 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-00-uv-in
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-00-bootstrap \
+# --- pip bootstrap (for building wheels) --------------------------------------
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-20-bootstrap \
     python -m pip install --upgrade pip setuptools wheel
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch \
+# --- Install pinned torch/torchaudio (prebuilt wheels via uv) -----------------
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-30-torch \
     uv pip install --system --no-cache-dir \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -86,10 +89,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-builder-01-torch
       torch==2.6.0+cu124 \
       torchaudio==2.6.0+cu124
 
-# Deterministic local build of mamba-ssm. We disable build isolation so the
-# build uses the Torch we pinned earlier in this stage, and we force source
-# build to avoid any network wheel guessing.
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-02-mamba \
+# --- Build wheels (source builds with pip wheel) -------------------------------
+# mamba-ssm from source; reuse pinned Torch in this stage.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-40-mamba \
     PIP_NO_BUILD_ISOLATION=1 MAMBA_FORCE_BUILD=TRUE \
     python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
@@ -99,7 +101,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-02-mam
       --wheel-dir /tmp/wheels \
       mamba-ssm==2.2.5
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-03-flashcausal \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-50-flashcausal \
     python -m pip wheel \
       -c constraints/torch-cu124-mamba.txt \
       --index-url ${TORCH_CUDA_INDEX_URL} \
@@ -109,7 +111,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-03-fla
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-04-vision \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-60-vision \
     if [ "$WITH_TORCHVISION" = "1" ]; then \
       python -m pip wheel \
         -c constraints/torch-cu124-mamba.txt \


### PR DESCRIPTION
## Summary
- ensure the builder bootstraps pip, setuptools, and wheel after installing uv
- switch mamba wheel builds to use python -m pip wheel with pip cache mounts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8f455cc88324b8915f7bb0d335bd