### PR TITLE
Remove torchvision build plumbing from Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@
 # MUST use the *devel* variant: compiles CUDA/C++ extensions (nvcc, headers).
 # Update digest with tools/docker/update_pytorch_digest.sh when refreshing base image
 # ========================================================
-ARG WITH_TORCHVISION=0
 FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel@sha256:0cf3402e946b7c384ba943ee05c90b4c5a4a05227923921f2b0918c011cfaf56 AS mamba-builder
-ARG WITH_TORCHVISION
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -116,24 +114,11 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-07-fla
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-zonos-builder-08-vision \
-    if [ "$WITH_TORCHVISION" = "1" ]; then \
-      PIP_NO_BUILD_ISOLATION=1 python -m pip wheel \
-        --no-deps \
-        -c constraints/torch-cu124-mamba.txt \
-        --index-url ${TORCH_CUDA_INDEX_URL} \
-        --extra-index-url ${PYPI_INDEX_URL} \
-        --no-binary=:all: \
-        --wheel-dir /tmp/wheels \
-        torchvision==0.21.0+cu124; \
-    fi
-
 # ========================================================
 # Stage 1 — Base layer with Python and system deps (slimmer runtime)
 # MUST use the *runtime* variant: only needs shared libs to import wheels.
 # ========================================================
 FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime@sha256:77f17f843507062875ce8be2a6f76aa6aa3df7f9ef1e31d9d7432f4b0f563dee AS base
-ARG WITH_TORCHVISION
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -255,11 +240,6 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-07-localwhe
       flash-attn==2.7.3 \
       causal-conv1d==1.5.0.post8
 
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-08-vision \
-    if [ "$WITH_TORCHVISION" = "1" ]; then \
-      uv pip install --system --no-cache-dir --find-links=/tmp/wheels \
-        torchvision==0.21.0+cu124; \
-    fi
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,7 +243,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-07-localwhe
 RUN rm -rf /tmp/wheels || true
 
 COPY pyproject.toml ./
-RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=vcs-sanity-zonos-base-09-scan \
+RUN --mount=type=cache,target=/root/.cache/vcs-scan,id=vcs-sanity-zonos-base-08-scan \
     python - <<'PY'
 from pathlib import Path
 import re
@@ -294,7 +294,7 @@ if suspicious:
 print('Editable install sanity: OK')
 PY
 COPY zonos ./zonos
-RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-10-editable \
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-09-editable \
     uv pip install --system --no-cache-dir --no-deps -e .
 
 RUN python - <<'PY'

--- a/constraints/torch-cu124-mamba.txt
+++ b/constraints/torch-cu124-mamba.txt
@@ -4,7 +4,5 @@
 # Core torch packages
 torch==2.6.0+cu124 ; platform_system == "Linux"
 torchaudio==2.6.0+cu124 ; platform_system == "Linux"
-# torchvision==0.21.0+cu124 ; platform_system == "Linux"  # Uncomment if torchvision is needed
-
 # Build helpers required by causal-conv1d and mamba-ssm
 ninja==1.11.1.1

--- a/constraints/torch-cu124-mamba.txt
+++ b/constraints/torch-cu124-mamba.txt
@@ -4,5 +4,6 @@
 # Core torch packages
 torch==2.6.0+cu124 ; platform_system == "Linux"
 torchaudio==2.6.0+cu124 ; platform_system == "Linux"
+
 # Build helpers required by causal-conv1d and mamba-ssm
 ninja==1.11.1.1


### PR DESCRIPTION
## Summary
- remove the WITH_TORCHVISION build argument and conditional wheel/install blocks from the Dockerfile
- drop the torchvision constraint hint since the image no longer supports toggling it on

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce939427708324a4a22f57202dd7d1