### PR TITLE
fix(runtime): ensure triton jit toolchain and drop torchvision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,17 +221,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05-torch \
       --index-url ${TORCH_CUDA_INDEX_URL} \
       --extra-index-url ${PYPI_INDEX_URL} \
       torch==2.6.0+cu124 \
-      torchaudio==2.6.0+cu124
-
-# Upstream runtime image can include torchvision; remove it explicitly.
-RUN python -m pip uninstall -y torchvision || true
-
-# Sanity check to confirm torchvision isn't importable.
-RUN python - <<'PY'
-import importlib.util
-
-print('torchvision present:', importlib.util.find_spec('torchvision') is not None)
-PY
+      torchaudio==2.6.0+cu124; \
+    python -m pip uninstall -y torchvision || true
 
 RUN python - <<'PY'
 import sys

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-zonos-base-02-apt \
     \
     # Install runtime deps quietly without recommendations.
     apt-get install -y -q --no-install-recommends \
+      build-essential \
       espeak-ng \
       ffmpeg \
       libsndfile1; \
@@ -221,6 +222,16 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05-torch \
       --extra-index-url ${PYPI_INDEX_URL} \
       torch==2.6.0+cu124 \
       torchaudio==2.6.0+cu124
+
+# Upstream runtime image can include torchvision; remove it explicitly.
+RUN python -m pip uninstall -y torchvision || true
+
+# Sanity check to confirm torchvision isn't importable.
+RUN python - <<'PY'
+import importlib.util
+
+print('torchvision present:', importlib.util.find_spec('torchvision') is not None)
+PY
 
 RUN python - <<'PY'
 import sys


### PR DESCRIPTION
## Summary
- install build-essential in the runtime image so Triton can compile at runtime
- uninstall torchvision from the runtime image and add a sanity check to confirm it's gone

## Testing
- not run (container build not executed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cebd9b84848324a89ee92ee8d4efdd