### PR TITLE
Use locked flag for uv export in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -271,9 +271,10 @@ print("Runtime Torch:", cur)
 assert cur == b, f"Builder/runtime Torch mismatch: {b} != {cur}"
 PY
 
-# Export the lock to a pip-readable constraints file
+# Export the lock to a pip-readable constraints file (from existing uv.lock)
+# NOTE: --frozen and --locked are mutually exclusive. Use --locked to rely strictly on uv.lock.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-05a-uvexport \
-    uv export --frozen --locked --format requirements-txt > /tmp/constraints.lock.txt
+    uv export --locked --format requirements-txt > /tmp/constraints.lock.txt
 
 # Install normal runtime deps under both constraints files (lock + torch/cu124)
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache-zonos-base-06-reqs \


### PR DESCRIPTION
## Summary
- ensure the Dockerfile exports requirements using `uv export --locked` so the build relies on the existing `uv.lock`
- clarify in comments that `--frozen` and `--locked` are mutually exclusive and explain why `--locked` is chosen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfd927e5d08324894f5d357172ce28